### PR TITLE
Fix helm-chart repo url

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -1,7 +1,7 @@
 title: kbatch Helm charts for Kubernetes
 description: This site stores Helm chart tarballs for kabtch
 theme: minima
-url: "https://kbatch-dev.github.io/kbatch"
+url: "https://kbatch-dev.github.io/helm-chart"
 repo_name: kbatch
 
 exclude:


### PR DESCRIPTION
Currently the helm-chart repo URL points to https://kbatch-dev.github.io/kbatch, which looks like an older version of this gh-pages site.

<img width="803" alt="Screen Shot 2022-06-16 at 15 22 12" src="https://user-images.githubusercontent.com/42120229/174187538-1c21ec04-82fc-4664-8e13-2409eb5a3164.png">

