### PR TITLE
Update helm chart version

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -24,7 +24,8 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: |
+          echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
@@ -33,4 +34,4 @@ jobs:
           charts_dir: "."
           charts_url: https://kbatch-dev.github.io/helm-chart
           linting: "off"
-          chart_version: ${{ steps.get_version.outputs.VERSION }}
+          chart_version: ${{ env.VERSION }}

--- a/kbatch/Chart.yaml
+++ b/kbatch/Chart.yaml
@@ -3,4 +3,4 @@ name: kbatch-proxy
 description: A Helm chart for kbatch-proxy
 type: application
 version: 0.0.1-set.by.chartpress
-appVersion: "0.4.1"
+appVersion: "0.4.2"


### PR DESCRIPTION
Update the helm chart version for kbatch.

(supersedes: https://github.com/kbatch-dev/kbatch/pull/57)

Apologies @TomAugspurger for all review requests. I forgot this repo existed and I was very confused on how the helm chart upgrades worked.  I'd also be happy to remove the duplicate helm-chart github pages if you're alright with it (see https://github.com/kbatch-dev/kbatch/issues/58).