### PR TITLE
add extraPodLabels, hub access label by default

### DIFF
--- a/kbatch/templates/deployment.yaml
+++ b/kbatch/templates/deployment.yaml
@@ -4,6 +4,11 @@ metadata:
   name: {{ include "kbatch-proxy.fullname" . }}
   labels:
     {{- include "kbatch-proxy.labels" . | nindent 4 }}
+    hub.jupyter.org/network-access-hub: "true"
+    {{- with .Values.extraPodLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/kbatch/values.yaml
+++ b/kbatch/values.yaml
@@ -26,6 +26,7 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
+extraPodLabels: {}
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
ensures network access to the hub with the default hub networkPolicy in the jupyterhub helm chart